### PR TITLE
Swipe Animation Tweak

### DIFF
--- a/src/component/gallery-image/gallery-image.component.ts
+++ b/src/component/gallery-image/gallery-image.component.ts
@@ -52,9 +52,11 @@ export class GalleryImageComponent implements OnInit {
         });
         /** Swipe next and prev */
         mc.on('swipeleft', () => {
+          this.renderer.addClass(el, 'g-swipe-invis');
           this.gallery.next();
         });
         mc.on('swiperight', () => {
+          this.renderer.addClass(el, 'g-swipe-invis');
           this.gallery.prev();
         });
       }
@@ -63,11 +65,13 @@ export class GalleryImageComponent implements OnInit {
 
   imageLoad(done: boolean) {
     this.loading = !done;
+    const el = this.el.nativeElement;
     /** TODO: Add some animation */
     
     if (!done) {
       this.animate = 'none';
     } else {
+      this.renderer.removeClass(el, 'g-swipe-invis');
       switch (this.config.animation) {
         case 'fade':
           this.animate = 'fade';

--- a/src/component/gallery-main/gallery-main.component.scss
+++ b/src/component/gallery-main/gallery-main.component.scss
@@ -48,6 +48,10 @@ gallery-main {
 }
 
 .g-pan-reset {
-  transition: all linear 0.3s;
+  transition: none;
   transform: translate3d(0px, 0px, 0px) !important;
+}
+
+.g-swipe-invis .g-image img {
+  opacity: 0;
 }


### PR DESCRIPTION
# Problem

Currently, if you swipe to the previous or next image, the image snap back into its original place and begin loading the next image. Most mobile users will find this animation awkward, since they expect the old image to exit from the visible viewport.

# Changes

- After swiping, the old image will be invisible until the new one has loaded